### PR TITLE
fix: update status_atual validation to allow multiple values for Codae and Escola requests

### DIFF
--- a/cypress/e2e/api/validar_codae_solicitacoes.cy.js
+++ b/cypress/e2e/api/validar_codae_solicitacoes.cy.js
@@ -569,9 +569,9 @@ describe('Validar rotas de Codae solicitações da aplicação SIGPAE', () => {
 				expect(response.body.results[0]).to.have.property('desc_doc')
 				expect(response.body.results[0]).to.have.property('status_evento')
 				expect(response.body.results[0]).to.have.property('motivo')
-				expect(response.body.results[0])
-					.to.have.property('status_atual')
-					.to.eq('CODAE_AUTORIZADO')
+				expect(response.body.results[0].status_atual).to.satisfy((value) => {
+					return value === 'INFORMADO' || value === 'CODAE_AUTORIZADO'
+				})
 				expect(response.body.results[0]).to.have.property('conferido')
 				expect(response.body.results[0]).to.have.property(
 					'terceirizada_conferiu_gestao',

--- a/cypress/e2e/api/validar_dre_solicitacoes.cy.js
+++ b/cypress/e2e/api/validar_dre_solicitacoes.cy.js
@@ -207,9 +207,9 @@ describe('Validar rotas de Diretoria Regional Solicitações da aplicação SIGP
 					expect(response.body.results[0]).to.have.property('desc_doc')
 					expect(response.body.results[0]).to.have.property('status_evento')
 					expect(response.body.results[0]).to.have.property('motivo')
-					expect(response.body.results[0])
-						.to.have.property('status_atual')
-						.to.eq('CODAE_AUTORIZADO')
+					expect(response.body.results[0].status_atual).to.satisfy((value) => {
+						return value === 'INFORMADO' || value === 'CODAE_AUTORIZADO'
+					})
 					expect(response.body.results[0]).to.have.property('conferido')
 					expect(response.body.results[0]).to.have.property(
 						'terceirizada_conferiu_gestao',

--- a/cypress/e2e/api/validar_escola_solicitacoes.cy.js
+++ b/cypress/e2e/api/validar_escola_solicitacoes.cy.js
@@ -106,7 +106,7 @@ describe('Validar rotas de Escola Solicitações da aplicação SIGPAE', () => {
 				expect(response.body.results[0]).to.have.property('motivo')
 				expect(response.body.results[0])
 					.to.have.property('status_atual')
-					.to.eq('CODAE_AUTORIZADO')
+					.to.eq('INFORMADO')
 				expect(response.body.results[0]).to.have.property('conferido')
 				expect(response.body.results[0]).to.have.property(
 					'terceirizada_conferiu_gestao',
@@ -198,9 +198,9 @@ describe('Validar rotas de Escola Solicitações da aplicação SIGPAE', () => {
 				expect(response.body.results[0]).to.have.property('desc_doc')
 				expect(response.body.results[0]).to.have.property('status_evento')
 				expect(response.body.results[0]).to.have.property('motivo')
-				expect(response.body.results[0])
-					.to.have.property('status_atual')
-					.to.eq('CODAE_AUTORIZADO')
+				expect(response.body.results[0].status_atual).to.satisfy((value) => {
+					return value === 'INFORMADO' || value === 'CODAE_AUTORIZADO'
+				})
 				expect(response.body.results[0]).to.have.property('conferido')
 				expect(response.body.results[0]).to.have.property(
 					'terceirizada_conferiu_gestao',
@@ -872,9 +872,9 @@ describe('Validar rotas de Escola Solicitações da aplicação SIGPAE', () => {
 				expect(response.body.results[0]).to.have.property('desc_doc')
 				expect(response.body.results[0]).to.have.property('status_evento')
 				expect(response.body.results[0]).to.have.property('motivo')
-				expect(response.body.results[0])
-					.to.have.property('status_atual')
-					.to.eq('DRE_VALIDADO')
+				expect(response.body.results[0].status_atual).to.satisfy((value) => {
+					return value === 'DRE_A_VALIDAR' || value === 'DRE_VALIDADO'
+				})
 				expect(response.body.results[0]).to.have.property('conferido')
 				expect(response.body.results[0]).to.have.property(
 					'terceirizada_conferiu_gestao',


### PR DESCRIPTION
<img width="953" height="595" alt="Captura de tela 2025-08-27 104738" src="https://github.com/user-attachments/assets/b96272ca-1972-46c7-a733-5a4cc024a752" />
